### PR TITLE
Moved up this semester on main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Sign up for our listserv by sending a blank email to [join-combee-rsg@lists.wisc
 ## Upcoming events
 **For Fall 2017, R Study Group will meet every other week on Thursdays at 2 PM in Microbial Sciences Building 5503, starting September 28th. See the schedule of topics [here](https://github.com/ComBEE-UW-Madison/RStudyGroup/tree/master/Fall2017)**
 
+[Fall 2017 Meetings](https://github.com/datascience-uwmadison/R_for_data_sciences#r-for-teams-in-the-data-sciences)
+
 This semester, [Brian Yandell](https://www.stat.wisc.edu/~yandell/) of the Statistics and Horticulture departments will be leading R Study Group. He will be teaching his prepared materials for a course he is developing, R for Data Sciences. The materials for his planned course and topics for the semester can be found [here](https://github.com/datascience-uwmadison/R_for_data_sciences). 
 
 To recieve updates about the coming semester meetings, sign up for our listserv by sending a blank email to [join-combee-rsg@lists.wisc.edu](mailto:join-combee-rsg@lists.wisc.edu). 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ To recieve updates about the coming semester meetings, sign up for our listserv 
 
 
 ## Previous Semesters' Meetings
-- [Fall 2017](https://github.com/datascience-uwmadison/R_for_data_sciences#r-for-teams-in-the-data-sciences)
 - [Prior to Summer 2017](https://github.com/ComBEE-UW-Madison/RStudyGroup/tree/master/Archive#r-study-group-archive)
 
 


### PR DESCRIPTION
This is similar to changes I PRed in python study group.

I still kind of think we should take Fall 2017 out of the "Previous Semesters" section...for both really but let me know what you think.

Sarah